### PR TITLE
feat(dark-mode-service): add loaded css class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img width="50%" height="50%" src="https://raw.githubusercontent.com/talohana/angular-dark-mode/master/logo.svg" />
+    <img width="50%" src="https://raw.githubusercontent.com/talohana/angular-dark-mode/master/logo.svg" />
 </p>
 
 <hr />
@@ -33,7 +33,7 @@ yarn add angular-dark-mode
 
 ## Usage
 
-In order to use angular-dark-mode you need to inject the service somewhere in your applications - presumably where you hold the dark mode toggle, and get the dark mode value from the exported `darkmode$` Observable:
+In order to use angular-dark-mode you need to inject the service somewhere in your applications - presumably where you hold the dark mode toggle, and get the dark mode value from the exported `darkMode$` Observable:
 
 ```ts
 // dark-mode-toggle.component.ts
@@ -42,7 +42,7 @@ In order to use angular-dark-mode you need to inject the service somewhere in yo
   selector: 'app-dark-mode-toggle',
   template: `<input
     type="checkbox"
-    [checked]="darkmode$ | async"
+    [checked]="darkMode$ | async"
     (change)="onToggle()"
   />`,
 })
@@ -94,12 +94,13 @@ Save and run your application, play with the toggle button to change between mod
 
 `angular-dark-mode` ships with the following options:
 
-| Option         |                 Description                 |   Default Value |
-| -------------- | :-----------------------------------------: | --------------: |
-| darkModeClass  |          dark mode css class name           |     `dark-mode` |
-| lightModeClass |          light mode css class name          |    `light-mode` |
-| storageKey     |    localStorage key to persist dark mode    |     `dark-mode` |
-| element        | target HTMLElement to set given css classes | `document.body` |
+| Option         |                  Description                  |      Default Value |
+| -------------- | :-------------------------------------------: | -----------------: |
+| darkModeClass  |           dark mode css class name            |        `dark-mode` |
+| lightModeClass |           light mode css class name           |       `light-mode` |
+| loadedClass    | css class name to flag the service has loaded | `dark-mode-loaded` |
+| storageKey     |     localStorage key to persist dark mode     |        `dark-mode` |
+| element        |  target HTMLElement to set given css classes  |    `document.body` |
 
 <br />
 
@@ -137,3 +138,20 @@ To resolve this problem include a file `no-flash.js` shipped with angular-dark-m
 ```
 
 In case you changed the default options, copy [`no-flash.js`](./projects/angular-dark-mode/no-flash.js) locally, configure it accordingly and include it in your `angular.json` scripts section.
+
+### Transitioning
+
+Most of the times we want to transition between light and dark modes, we can do this by adding `transition` property to the body element for example.
+
+In order to prevent the initial transition you can use the `loadedClass` option which sets a css class to the provided `element` once the service has loaded, for example:
+
+```css
+/* styles.css */
+...
+
+body.dark-mode-loaded {
+  transition: all 0.3s linear;
+}
+
+...
+```

--- a/projects/angular-dark-mode/src/lib/dark-mode.service.ts
+++ b/projects/angular-dark-mode/src/lib/dark-mode.service.ts
@@ -29,6 +29,7 @@ export class DarkModeService {
     this.renderer = this.rendererFactory.createRenderer(null, null);
     this.darkModeSubject$ = new BehaviorSubject(this.getInitialDarkModeValue());
     this.darkModeSubject$.getValue() ? this.enable() : this.disable();
+    this.addLoadedClass();
   }
 
   /**
@@ -89,5 +90,12 @@ export class DarkModeService {
     }
 
     return null;
+  }
+
+  private addLoadedClass(): void {
+    // Defer to next tick
+    setTimeout(() => {
+      this.renderer.addClass(this.options.element, this.options.loadedClass);
+    });
   }
 }

--- a/projects/angular-dark-mode/src/lib/default-options.ts
+++ b/projects/angular-dark-mode/src/lib/default-options.ts
@@ -6,6 +6,7 @@ import { DarkModeOptions } from './types';
 export const defaultOptions: DarkModeOptions = {
   darkModeClass: 'dark-mode',
   lightModeClass: 'light-mode',
+  loadedClass: 'dark-mode-loaded',
   storageKey: 'dark-mode',
   element: document.body,
 };

--- a/projects/angular-dark-mode/src/lib/tests/dark-mode.service.spec.ts
+++ b/projects/angular-dark-mode/src/lib/tests/dark-mode.service.spec.ts
@@ -1,4 +1,5 @@
 import { Renderer2, RendererFactory2 } from '@angular/core';
+import { fakeAsync, tick } from '@angular/core/testing';
 import { hot } from 'jest-marbles';
 import { when } from 'jest-when';
 import { DarkModeService } from '../dark-mode.service';
@@ -151,6 +152,19 @@ describe('DarkModeService', () => {
         providedOptions.lightModeClass
       );
     });
+
+    it('should set loadedClass after loading', fakeAsync(() => {
+      createService();
+
+      tick();
+
+      // one for enable/disable and next for adding loaded class
+      expect(rendererMock.addClass).toHaveBeenCalledTimes(2);
+      expect(rendererMock.addClass).toHaveBeenCalledWith(
+        defaultOptions.element,
+        defaultOptions.loadedClass
+      );
+    }));
   });
 
   describe('toggle', () => {

--- a/projects/angular-dark-mode/src/lib/types.ts
+++ b/projects/angular-dark-mode/src/lib/types.ts
@@ -1,6 +1,7 @@
 export interface DarkModeOptions {
   darkModeClass: string;
   lightModeClass: string;
+  loadedClass: string;
   storageKey: string;
   element: HTMLElement;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -3,6 +3,10 @@ body {
   font-family: 'Roboto', sans-serif;
 }
 
+body.dark-mode-loaded {
+  transition: all 0.3s linear;
+}
+
 body.dark-mode {
   background-color: #2d3436;
   color: #dfe6e9;


### PR DESCRIPTION
Added loadedClass option to flag when dark-mode.service finished setup
primarily used to make transitions easier to implement