### PR TITLE
ci: disable persist-credentials for release stage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       
       - name: Setup Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
Following [1] to support pushing to protected branches (main)

[1] https://github.com/semantic-release/semantic-release/blob/8fda7fd423d24e7b425fbee83790f49dd0478e2d/docs/recipes/ci-configurations/github-actions.md#pushing-packagejson-changes-to-a-master-branch